### PR TITLE
Add anonymous user functionality

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1,15 +1,15 @@
 import Firebase from 'firebase'
 
 let config = {
-  apiKey: "AIzaSyDfxRhV6rSmLkL4VQrLaBFrZfDLhC5rX9E",
-  authDomain: "pantreats.firebaseapp.com",
-  databaseURL: "https://pantreats.firebaseio.com",
-  projectId: "pantreats",
-  storageBucket: "pantreats.appspot.com",
-  messagingSenderId: "599821562839"
-}
+  apiKey: "AIzaSyCFr2V5mjFFDLFcuK3ODv-ek64zeC77qAg",
+  authDomain: "pantreats-test.firebaseapp.com",
+  databaseURL: "https://pantreats-test.firebaseio.com",
+  projectId: "pantreats-test",
+  storageBucket: "pantreats-test.appspot.com",
+  messagingSenderId: "262635869705"
+};
 
-const app = Firebase.initializeApp(config)
-const db = app.database()
+const app = Firebase.initializeApp(config);
+const db = app.database();
 
 export default db

--- a/src/partials/MainNav.vue
+++ b/src/partials/MainNav.vue
@@ -206,7 +206,7 @@
     // TODO: The unauthenticated view is briefly visible on refresh; how can we avoid this?
     mounted: function() {
       Firebase.auth().onAuthStateChanged((user) => {
-        if (user) {
+        if (user && !user.isAnonymous) {
           this.isUserLoggedIn = true;
         }
       })
@@ -223,6 +223,10 @@
           selections.forEach((ingredient) => {
             this.ingredientsToAdd = [];
             if (!(pantry.includes(ingredient))) {
+              // If the user isn't accounted for, sign them up anonymously
+              if (!Firebase.auth().currentUser) {
+                this.registerAnonymousUser();
+              }
               pantry.push(ingredient);
             } else {
               let index = pantry.indexOf(ingredient);
@@ -266,6 +270,9 @@
         this.email = undefined;
         this.password = undefined;
       },
+      registerAnonymousUser() {
+        Firebase.auth().signInAnonymously();
+      },
       login(event) {
         Firebase.auth().signInWithEmailAndPassword(this.email, this.password).then((user) => {
           // Login was successful
@@ -305,6 +312,7 @@
         });
       },
       googleSignin(event) {
+        // TODO: Should anonymous users be able to convert through sign-in or do we want a dedicated "register with Google creds?"
         const provider = new Firebase.auth.GoogleAuthProvider();
         Firebase.auth().signInWithPopup(provider).then((result) => {
           this.hideAndClearMenu();


### PR DESCRIPTION
When an unregistered user modifies the pantry for the first time, they become registered as an anonymous user. They have the same limitations as before, but their pantry modifications will be saved to Firebase and persisted on subsequent visits to the site from that browser. If they choose to register with the site, their anonymous account data will be transferred to the new account.